### PR TITLE
Crimetype Dropdown Is Invalid

### DIFF
--- a/agile-app/src/components/searchComboBox/mapSearchComboBox.tsx
+++ b/agile-app/src/components/searchComboBox/mapSearchComboBox.tsx
@@ -3,7 +3,6 @@ import { getUniqueCrimeTypes } from '@/scripts/dataFetching'
 import React, {useEffect, useState} from 'react'
 import SearchComboBox from './searchComboBox'
 import styles from './searchComboBox.module.css'
-import { get } from 'http'
 
 /**
  * The data passed to the component must follow the interface ParentSearchComboBoxProps found below
@@ -50,7 +49,7 @@ const MapParentSearchComboBox: React.FC<MapParentSearchComboBoxProps> = ({ setSe
     };
 
 
-    /** list containing all the types of crimes that can be filtered on*/
+    /** Effect hook which gets the list of unique crime types of type string[] and sets the state variable to this value*/
     useEffect(() => {
         const fetchCrimeTypes = async () => {
             getUniqueCrimeTypes().then((result) => {
@@ -73,6 +72,8 @@ const MapParentSearchComboBox: React.FC<MapParentSearchComboBoxProps> = ({ setSe
                     <SearchComboBox title="Filtrera på kommun eller län: " options={optionsLoc} onSelect={handleSelectLoc} selectedOption={selectedOptionLoc} />
                 </div>
                 <div className={styles.innerContainer} >
+                    {/*Displays the search combo box once the crime options have been successfully fetched.*/}
+                    {/*Otherwise displays a loading message to the user*/}
                     {optionsCrime.length != 0
                         ? (
                             <SearchComboBox

--- a/agile-app/src/components/searchComboBox/mapSearchComboBox.tsx
+++ b/agile-app/src/components/searchComboBox/mapSearchComboBox.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { getUniqueCrimeTypes } from '@/scripts/dataFetching'
-import React, {useState} from 'react'
+import React, {useEffect, useState} from 'react'
 import SearchComboBox from './searchComboBox'
 import styles from './searchComboBox.module.css'
 import { get } from 'http'
@@ -23,7 +23,8 @@ interface MapParentSearchComboBoxProps {
  * @returns {JSX} A React component representing the ParentSearchComboBox.
  */
 const MapParentSearchComboBox: React.FC<MapParentSearchComboBoxProps> = ({ setSelectedOptionCrime, setSelectedOptionLoc , setShowMarkers, showMarkers, selectedOptionCrime, selectedOptionLoc}) => {
-    const [markerText, setMarkerText] = useState<string>("Dölj Markeringar")
+    const [markerText, setMarkerText] = useState<string>("Dölj Markeringar");
+    const [optionsCrime, setOptionsCrime] = useState<string[]>([]);
 
     const handleSelectCrime = (selectedOption: string) => {
         setSelectedOptionCrime(selectedOption);
@@ -50,7 +51,14 @@ const MapParentSearchComboBox: React.FC<MapParentSearchComboBoxProps> = ({ setSe
 
 
     /** list containing all the types of crimes that can be filtered on*/
-    const optionsCrime = getUniqueCrimeTypes();
+    useEffect(() => {
+        const fetchCrimeTypes = async () => {
+            getUniqueCrimeTypes().then((result) => {
+                setOptionsCrime(result)
+            })
+        }
+        fetchCrimeTypes()
+    })
     
     /** list containing all the locations that can be filtered on*/
     const optionsLoc = [
@@ -64,8 +72,22 @@ const MapParentSearchComboBox: React.FC<MapParentSearchComboBoxProps> = ({ setSe
                 <div className={styles.innerContainer}>
                     <SearchComboBox title="Filtrera på kommun eller län: " options={optionsLoc} onSelect={handleSelectLoc} selectedOption={selectedOptionLoc} />
                 </div>
-                <div className={styles.innerContainer} > 
-                    <SearchComboBox title="Filtrera på brottstyp: " options={optionsCrime} onSelect={handleSelectCrime} selectedOption={selectedOptionCrime}/>
+                <div className={styles.innerContainer} >
+                    {optionsCrime.length != 0
+                        ? (
+                            <SearchComboBox
+                                title="Filtrera på brottstyp: "
+                                options={optionsCrime}
+                                onSelect={handleSelectCrime}
+                                selectedOption={selectedOptionCrime}
+                            />
+                        )
+                        : (
+                            <div className={styles.comboContainer}>
+                                <label>{"Filtrera på brottstyp: "}</label>
+                                <label>Laddar in tillgängliga brottstyper</label>
+                            </div>
+                        )}
                 </div>
                 <button className={styles.button} onClick={resetChoices}>Återställ val</button>
                 <button className={styles.button} onClick={handleSelectMarker}>{markerText}</button>

--- a/agile-app/src/components/searchComboBox/parentSearchComboBox.tsx
+++ b/agile-app/src/components/searchComboBox/parentSearchComboBox.tsx
@@ -3,6 +3,7 @@
 import SearchComboBox from './searchComboBox'
 import styles from './searchComboBox.module.css'
 import {getUniqueCrimeTypes} from "@/scripts/dataFetching";
+import React, {useEffect, useState} from "react";
 
 /**
  * The data passed to the component must follow the interface ParentSearchComboBoxProps found below
@@ -20,6 +21,7 @@ interface ParentSearchComboBoxProps {
  * @returns {JSX} A React component representing the ParentSearchComboBox.
  */
 const ParentSearchComboBox: React.FC<ParentSearchComboBoxProps> = ({ setSelectedOptionCrime, setSelectedOptionLoc , selectedOptionCrime, selectedOptionLoc}) => {
+    const [optionsCrime, setOptionsCrime] = useState<string[]>([]);
 
     const handleSelectCrime = (selectedOption: string) => {
         setSelectedOptionCrime(selectedOption);
@@ -35,8 +37,14 @@ const ParentSearchComboBox: React.FC<ParentSearchComboBoxProps> = ({ setSelected
     };
 
     /** list containing all the crime types that can be filtered on. Get the array from dataFetching.ts */
-    const optionsCrime = getUniqueCrimeTypes()
-
+    useEffect(() => {
+        const fetchCrimeTypes = async () => {
+            getUniqueCrimeTypes().then((result) => {
+                setOptionsCrime(result)
+            })
+        }
+        fetchCrimeTypes()
+    })
 
     /** list containing all the locations that can be filtered on*/
     const optionsLoc = [
@@ -364,13 +372,22 @@ const ParentSearchComboBox: React.FC<ParentSearchComboBoxProps> = ({ setSelected
                         selectedOption={selectedOptionLoc}
                     />
                 </div>
-                <div className={styles.innerContainer} > 
-                    <SearchComboBox
-                        title="Filtrera på brottstyp: "
-                        options={optionsCrime}
-                        onSelect={handleSelectCrime}
-                        selectedOption={selectedOptionCrime}
-                    />
+                <div className={styles.innerContainer} >
+                    {optionsCrime.length != 0
+                    ? (
+                            <SearchComboBox
+                                title="Filtrera på brottstyp: "
+                                options={optionsCrime}
+                                onSelect={handleSelectCrime}
+                                selectedOption={selectedOptionCrime}
+                            />
+                        )
+                    : (
+                            <div className={styles.comboContainer}>
+                                <label>{"Filtrera på brottstyp: "}</label>
+                                <label>Laddar in tillgängliga brottstyper</label>
+                            </div>
+                        )}
                 </div>
                 <button className={styles.button} onClick={resetChoices}>Återställ val</button>
             </div>

--- a/agile-app/src/components/searchComboBox/parentSearchComboBox.tsx
+++ b/agile-app/src/components/searchComboBox/parentSearchComboBox.tsx
@@ -36,7 +36,7 @@ const ParentSearchComboBox: React.FC<ParentSearchComboBoxProps> = ({ setSelected
         handleSelectLoc("")
     };
 
-    /** list containing all the crime types that can be filtered on. Get the array from dataFetching.ts */
+    /** Effect hook which gets the list of unique crime types of type string[] and sets the state variable to this value*/
     useEffect(() => {
         const fetchCrimeTypes = async () => {
             getUniqueCrimeTypes().then((result) => {
@@ -373,6 +373,8 @@ const ParentSearchComboBox: React.FC<ParentSearchComboBoxProps> = ({ setSelected
                     />
                 </div>
                 <div className={styles.innerContainer} >
+                    {/*Displays the search combo box once the crime options have been successfully fetched.*/}
+                    {/*Otherwise displays a loading message to the user*/}
                     {optionsCrime.length != 0
                     ? (
                             <SearchComboBox

--- a/agile-app/src/scripts/dataFetching.ts
+++ b/agile-app/src/scripts/dataFetching.ts
@@ -1,4 +1,6 @@
 // Interface for storing the data fetched from the API
+import {all} from "deepmerge";
+
 export interface CrimeData {
     id: number;
     datetime: string;
@@ -28,26 +30,27 @@ export async function getCrimeData(): Promise<CrimeData[]>{
     return fetchedCrimeData;
 }
 
-// Array of strings for the crimeOptions
 let crimeTypes: string[] = [];
 
 /** Function that populates crimeOptions array */
 const populateCrimeOptions = async () => {
-    const allCrimes: CrimeData[] = await getCrimeData();
-    const uniqueCrimeTypes = new Set<string>(); /** Using a set to avoid duplicates */
+    if (crimeTypes.length == 0) {
+        // Array of strings for the crimeOptions
+        const allCrimes: CrimeData[] = await getCrimeData();
+        const uniqueCrimeTypes = new Set<string>(); /** Using a set to avoid duplicates */
 
-    allCrimes.forEach(crime => {
-        uniqueCrimeTypes.add(crime.type);
-    });
+        allCrimes.forEach(crime => {
+            uniqueCrimeTypes.add(crime.type);
+        });
 
-    crimeTypes = Array.from(uniqueCrimeTypes).sort();
-    crimeTypes.unshift(""); /** Adds an empty string as the first element */
+        crimeTypes = Array.from(uniqueCrimeTypes).sort();
+        crimeTypes.unshift(""); /** Adds an empty string as the first element */
+    }
 };
-
-populateCrimeOptions();
 
 /** Function that returns the crimeOptions after it's populated
  * @returns crimeTypes - Array of crime types */
-export const getUniqueCrimeTypes = () => {
-    return crimeTypes;
+export const getUniqueCrimeTypes = async () => {
+    await populateCrimeOptions();
+    return crimeTypes
 };

--- a/agile-app/src/scripts/dataFetching.ts
+++ b/agile-app/src/scripts/dataFetching.ts
@@ -32,7 +32,9 @@ export async function getCrimeData(): Promise<CrimeData[]>{
 
 let crimeTypes: string[] = [];
 
-/** Function that populates crimeOptions array */
+/** Function that populates crimeOptions array if the array is empty. Otherwise, does nothing.
+ * This is workaround since the population of the list is almost always slower than rendering the
+ * component that uses it. Therefore, once populated it simply ends.*/
 const populateCrimeOptions = async () => {
     if (crimeTypes.length == 0) {
         // Array of strings for the crimeOptions
@@ -48,7 +50,8 @@ const populateCrimeOptions = async () => {
     }
 };
 
-/** Function that returns the crimeOptions after it's populated
+/** Function that returns the crimeTypes after it's populated
+ * If crimeTypes is already populated the "await" is instantly skipped and the variable returned.
  * @returns crimeTypes - Array of crime types */
 export const getUniqueCrimeTypes = async () => {
     await populateCrimeOptions();


### PR DESCRIPTION
This issue is now resolved. Upon rendering the page with a parentSearchComboBox the option for crime type displays a loading message and then shows the listed crime types once they have finished fetching from dataFetching.ts

![image](https://github.com/willayy/DAT257-Agile/assets/107652880/bae2ffa1-e4a1-46db-9b12-ed2cb7e082db)